### PR TITLE
feat: Add Livewire v4 support with backward compatibility for v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "livewire/livewire": "^3.0"
+        "livewire/livewire": "^3.0|^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.8",
-        "larastan/larastan": "^2.9",
-        "orchestra/testbench": "^9.0",
+        "larastan/larastan": "^2.9|^3.0",
+        "orchestra/testbench": "^9.0|^10.0",
         "phpunit/phpunit": "^11.1"
     },
     "autoload": {

--- a/src/LivewireRecaptcha.php
+++ b/src/LivewireRecaptcha.php
@@ -15,10 +15,10 @@ class LivewireRecaptcha
      * @return string
      */
     public static function directive(
-        string $version = null,
-        string $siteKey = null,
-        string $theme = null,
-        string $size = null,
+        ?string $version = null,
+        ?string $siteKey = null,
+        ?string $theme = null,
+        ?string $size = null,
     ): string {
         $version ??= config('services.google.recaptcha.version') ?? 'v3';
 


### PR DESCRIPTION
- Update livewire/livewire constraint to ^3.0|^4.0
- Update orchestra/testbench to ^9.0|^10.0 for Laravel 11/12 compatibility
- Update larastan/larastan to ^2.9|^3.0 for PHPStan 1.x/2.x compatibility
- Fix PHP 8.4 implicit nullable parameter deprecations in LivewireRecaptcha::directive()

No breaking changes - the internal Livewire APIs used by this package
(SupportAttributes\Attribute, trigger(), wrap(), and JavaScript hooks)
remain compatible across both versions.